### PR TITLE
Added manual bypass for is_dld_done_writing 

### DIFF
--- a/lib/import_mcp_tdc_data/import_mcp_tdc_data.m
+++ b/lib/import_mcp_tdc_data/import_mcp_tdc_data.m
@@ -13,25 +13,25 @@ import_opts=rmfield(import_opts,'force_load_save');
 if ~isfield(import_opts,'force_forc')
     import_opts.force_forc=false;
 end
+if import_opts.force_forc %if force_forc then have to skip the cache
+    import_opts.force_reimport=true;
+end
 
 if ~isfield(import_opts,'force_reimport')
     import_opts.force_reimport=false;
 end
 cache_opts.force_recalc=import_opts.force_reimport;
 import_opts=rmfield(import_opts,'force_reimport');
+
+if ~isfield(import_opts,'force_cache_load')
+    import_opts.force_cache_load=false;
+end
+cache_opts.force_cache_load=import_opts.force_cache_load;
+import_opts=rmfield(import_opts,'force_cache_load');
 
 % if ~isfield(import_opts,'no_save')
 %     %to be completed, requires modification to function_cache
 % end
-
-if import_opts.force_forc %if force_forc then have to skip the cache
-    import_opts.force_reimport=true;
-end
-if ~isfield(import_opts,'force_reimport')
-    import_opts.force_reimport=false;
-end
-cache_opts.force_recalc=import_opts.force_reimport;
-import_opts=rmfield(import_opts,'force_reimport');
 
 if isfield(import_opts,'out_dir')
     cache_opts.dir = import_opts.out_dir;
@@ -108,6 +108,7 @@ if ~isfield(import_opts, 'force_forc') ,import_opts.force_forc=false; end
 if ~isfield(import_opts, 'file_name') ,import_opts.file_name='d'; end
 if ~isfield(import_opts, 'dld_xy_rot') ,import_opts.dld_xy_rot=0.61; end
 if ~isfield(import_opts, 'txylim') ,import_opts.txylim=[[0,10];[-30e-3, 30e-3];[-30e-3, 30e-3]]; end
+if ~isfield(import_opts, 'from_archive'),import_opts.from_archive = false; end
 %if the shot numbers are not specified import everythin in the directory
 if ~isfield(import_opts,'shot_num') 
     import_opts.shot_num=find_data_files(import_opts);
@@ -144,6 +145,14 @@ for ii=1:size(import_opts.shot_num,2)
     elseif ~is_dld_done_writing(import_opts.dir,[import_opts.file_name,num2str(import_opts.shot_num(ii)),'.txt'],import_opts.mod_wait)
         fprintf(2,'\n data file not done writing will not process %04i \n %04i\n',import_opts.shot_num(ii),ii)
     else
+        if ~import_opts.from_archive 
+            % If you trust the directory, you can bypass the following function.
+            % This can cut runtime in half, but is only safe if data isn't
+            % currently being taken.
+            if ~is_dld_done_writing(import_opts.dir,[import_opts.file_name,num2str(import_opts.shot_num(ii)),'.txt'],import_opts.mod_wait)
+                fprintf(2,'\n data file not done writing will not process %04i \n %04i\n',import_opts.shot_num(ii),ii)
+            end
+        else
          mcp_tdc_data.time_create_write(ii,:)=data_tcreate([import_opts.dir,import_opts.file_name],num2str(import_opts.shot_num(ii)));
          %if the txy_forc does not exist, if import_opts.force_forc, or the forc file was earlier than the dld file (re) make it
          if ~convert_dld_to_txy && ...
@@ -170,6 +179,7 @@ for ii=1:size(import_opts.shot_num,2)
          mcp_tdc_data.counts_txy{ii}=txydata*[1 0 0;0 cos(alpha) -sin(alpha); 0 sin(alpha) cos(alpha)];
          mcp_tdc_data.num_counts(ii)=size(txydata,1);
          mcp_tdc_data.shot_num(ii)=import_opts.shot_num(ii);
+        end
     end %file exists condition
     fprintf('\b\b\b\b%04i',ii)
 end


### PR DESCRIPTION
The is_dld_done_writing function is not generally required when importing trusted data (i.e. has been archived/imported before).
The default function is same as previous version, but manually setting import_opts.from_archive=true will skip running is_dld_done_writing on every iteration of import function, saving considerable time (2.5x in my tests).
Also there was some redundancy in the option initialization which has been fixed.